### PR TITLE
Build commands table

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -143,7 +143,8 @@ export default defineConfig({
                         { text: 'Overview', link: '/examples/' },
                         { text: 'Simple List Navigation', link: '/examples/simple-list' },
                         { text: 'Understanding Dimensions', link: '/examples/understanding-dimensions' },
-                        { text: 'Dimensions API Example', link: '/examples/dimensions-api' }
+                        { text: 'Dimensions API Example', link: '/examples/dimensions-api' },
+                        { text: 'Commands Instructions', link: '/examples/commands-instructions' }
                     ]
                 },
                 {

--- a/docs/examples/commands-instructions.md
+++ b/docs/examples/commands-instructions.md
@@ -1,0 +1,645 @@
+# Commands Instructions
+
+This example shows how the rendering module can be used to automatically generate a commands instructions table for your data visualization. The commands can be explicitely set or generated from the navigations rules.
+
+## Generation from navigation rules
+
+<button class="toggle-controls" :aria-expanded="showControls" @click="showControls = !showControls">{{ showControls ? 'Hide controls' : 'Show controls' }}</button>
+
+<div v-show="showControls">
+    <div id="commands-root"></div>
+</div>
+
+<div>
+    <h3>Bar Chart</h3>
+    <div id="chart-wrapper" style="position: relative;">
+        <div id="chart"></div>
+    </div>
+</div>
+
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue';
+
+const showControls = ref(true);
+let cleanup = null;
+
+onMounted(async () => {
+    const waitFor = (check, timeout = 5000) => new Promise((resolve, reject) => {
+        const start = Date.now();
+        const poll = () => {
+            if (check()) resolve();
+            else if (Date.now() - start > timeout) reject(new Error('Timeout'));
+            else setTimeout(poll, 50);
+        };
+        poll();
+    });
+
+    try {
+        await waitFor(() => typeof Bokeh !== 'undefined' && Bokeh.Plotting);
+        await waitFor(() => document.getElementById('chart'));
+
+        const { default: dataNavigator } = await import('data-navigator');
+
+        const chartWidth = 300;
+        const chartHeight = 300;
+
+        // Data for programmatically drawing focus outlines
+        const interactiveData = {
+            data: [
+                [[3, 2.75], [0, 0]],      // apple: [top values], [bottom values]
+                [[3.75, 4], [3, 2.75]]     // banana: [top values], [bottom values]
+            ],
+            indices: {
+                fruit: { apple: 0, banana: 1 },
+                store: { a: 0, b: 1 }
+            }
+        };
+
+        // Function to draw Bokeh chart with optional focus indicator
+        const drawChart = (focusData) => {
+            const container = document.getElementById('chart');
+            container.innerHTML = '';
+
+            const stores = ['a', 'b'];
+            const plt = Bokeh.Plotting;
+            const p = plt.figure({
+                x_range: stores, y_range: [0, 5.5],
+                height: chartHeight, width: chartWidth,
+                title: 'Fruit cost by store', output_backend: 'svg',
+                toolbar_location: null, tools: ''
+            });
+
+            // Apple bars (bottom)
+            p.vbar({ x: stores, top: [3, 2.75], bottom: [0, 0], width: 0.8,
+                     color: '#FCB5B6', line_color: '#8F0002' });
+            // Banana bars (stacked on top)
+            p.vbar({ x: stores, top: [3.75, 4], bottom: [3, 2.75], width: 0.8,
+                     color: '#F9E782', line_color: '#766500' });
+
+            // Draw focus indicator outline if provided
+            if (focusData) {
+                p.vbar({
+                    x: stores,
+                    top: focusData.top,
+                    bottom: focusData.bottom,
+                    width: 0.8,
+                    line_width: 3,
+                    color: ['transparent', 'transparent'],
+                    line_color: focusData.line_color
+                });
+            }
+
+            // Legend
+            const r1 = p.square([-10000], [-10000], { color: '#FCB5B6', line_color: '#8F0002' });
+            const r2 = p.square([-10000], [-10000], { color: '#F9E782', line_color: '#766500' });
+            p.add_layout(new Bokeh.Legend({
+                items: [
+                    new Bokeh.LegendItem({ label: 'apple', renderers: [r1] }),
+                    new Bokeh.LegendItem({ label: 'banana', renderers: [r2] })
+                ],
+                location: 'top_left', orientation: 'horizontal'
+            }));
+
+            plt.show(p, '#chart');
+
+            // Hide Bokeh's inaccessible elements from AT
+            const bokehPlot = document.querySelector('#chart');
+            if (bokehPlot) bokehPlot.setAttribute('inert', 'true');
+        };
+
+        // Initial chart draw (no focus)
+        drawChart(null);
+
+        // Define structure
+        let exitHandler = null;
+
+        const structure = {
+            nodes: {
+                _0: {
+                    id: '_0', renderId: '_0',
+                    data: { fruit: 'apple', store: 'a', cost: 3 },
+                    edges: ['_0-_1', 'any-exit'],
+                    semantics: { label: 'fruit: apple. store: a. cost: 3. Data point.' },
+                    spatialProperties: { x: 0, y: 0, width: chartWidth, height: chartHeight }
+                },
+                _1: {
+                    id: '_1', renderId: '_1',
+                    data: { fruit: 'banana', store: 'a', cost: 0.75 },
+                    edges: ['_0-_1', '_1-_2', 'any-exit'],
+                    semantics: { label: 'fruit: banana. store: a. cost: 0.75. Data point.' },
+                    spatialProperties: { x: 0, y: 0, width: chartWidth, height: chartHeight }
+                },
+                _2: {
+                    id: '_2', renderId: '_2',
+                    data: { fruit: 'apple', store: 'b', cost: 2.75 },
+                    edges: ['_1-_2', '_2-_3', 'any-exit'],
+                    semantics: { label: 'fruit: apple. store: b. cost: 2.75. Data point.' },
+                    spatialProperties: { x: 0, y: 0, width: chartWidth, height: chartHeight }
+                },
+                _3: {
+                    id: '_3', renderId: '_3',
+                    data: { fruit: 'banana', store: 'b', cost: 1.25 },
+                    edges: ['_2-_3', 'any-exit'],
+                    semantics: { label: 'fruit: banana. store: b. cost: 1.25. Data point.' },
+                    spatialProperties: { x: 0, y: 0, width: chartWidth, height: chartHeight }
+                }
+            },
+            edges: {
+                '_0-_1': { source: '_0', target: '_1', navigationRules: ['left', 'right'] },
+                '_1-_2': { source: '_1', target: '_2', navigationRules: ['left', 'right'] },
+                '_2-_3': { source: '_2', target: '_3', navigationRules: ['left', 'right'] },
+                'any-exit': {
+                    source: (d, c) => c,
+                    target: () => { if (exitHandler) exitHandler(); return ''; },
+                    navigationRules: ['exit']
+                }
+            },
+            navigationRules: {
+                left: { key: 'ArrowLeft', direction: 'source' },
+                right: { key: 'ArrowRight', direction: 'target' },
+                exit: { key: 'Escape', direction: 'target' }
+            }
+        };
+
+        // State
+        let current = null;
+        let previous = null;
+
+        // Draw focus indicator on the Bokeh chart
+        const drawFocusIndicator = (node) => {
+            if (!node?.data) return;
+
+            const fruitIndex = interactiveData.indices.fruit[node.data.fruit];
+            const storeIndex = interactiveData.indices.store[node.data.store];
+            const barData = interactiveData.data[fruitIndex];
+
+            const line_color = storeIndex === 0 ? ['#000000', 'transparent'] : ['transparent', '#000000'];
+
+            drawChart({
+                top: barData[0],
+                bottom: barData[1],
+                line_color
+            });
+        };
+
+        // Set up rendering
+        const enter = () => {
+            const nextNode = input.enter();
+            if (nextNode) initiateLifecycle(nextNode);
+        };
+
+        const rendering = dataNavigator.rendering({
+            elementData: structure.nodes,
+            defaults: { cssClass: 'dn-manual-focus-node' },
+            suffixId: 'simple-list',
+            root: {
+                id: 'chart-wrapper',
+                description: 'Fruit cost by store chart. Use arrow keys to navigate.',
+                width: '100%',
+                height: 0
+            },
+            entryButton: { include: true, callbacks: { click: enter } },
+            exitElement: { include: true },
+            commandsElement: {
+                include: true,
+                rootId: 'commands-root',
+                navigationRules: structure.navigationRules,
+            },
+        });
+
+        rendering.initialize();
+
+        exitHandler = () => {
+            rendering.exitElement.style.display = 'block';
+            input.focus(rendering.exitElement.id);
+            if (current) {
+                rendering.remove(current);
+                current = null;
+            }
+            drawChart(null);
+        };
+
+        // Set up input handler
+        const input = dataNavigator.input({
+            structure,
+            navigationRules: structure.navigationRules,
+            entryPoint: '_0',
+            exitPoint: rendering.exitElement?.id
+        });
+
+        // Navigation lifecycle
+        const move = (direction) => {
+            const nextNode = input.move(current, direction);
+            if (nextNode) initiateLifecycle(nextNode);
+        };
+
+        const initiateLifecycle = (nextNode) => {
+            if (previous) rendering.remove(previous);
+
+            const element = rendering.render({ renderId: nextNode.renderId, datum: nextNode });
+
+            element.addEventListener('keydown', (e) => {
+                const direction = input.keydownValidator(e);
+                if (direction) { e.preventDefault(); move(direction); }
+            });
+
+            element.addEventListener('focus', () => {
+                drawFocusIndicator(nextNode);
+            });
+
+            input.focus(nextNode.renderId);
+            previous = current;
+            current = nextNode.id;
+        };
+
+        cleanup = () => { if (rendering) rendering.clearStructure(); };
+    } catch (e) {
+        console.error('Failed to initialize:', e);
+        const container = document.getElementById('chart');
+        if (container) {
+            container.innerHTML = `<p style="color: var(--vp-c-danger-1);">Error: ${e.message}</p>`;
+        }
+    }
+});
+
+onUnmounted(() => { if (cleanup) cleanup(); });
+</script>
+
+### About This Example
+
+This is the same chart and structure from the [Getting Started guide](/getting-started/first-chart), shown here with a command table above that was generated automatically by modifying the rendering options.
+
+In this example, we specify a `commandsElement.rootId` in the rendering options that matches the id of the HTML node the table will be injected into. The command table content is deduced from the `navigationRules` that need to be passed to the rendering options.
+
+If the `title` option is specified, it adds a `caption` HTML element as the first child of the table.
+
+```js
+const rendering = dataNavigator.rendering({
+    ...
+    commandsElement: {
+        include: true,
+        rootId: 'commands-root',
+        title: 'Commands instructions',
+        navigationRules: structure.navigationRules,
+    },
+});
+```
+
+### Modifying the list of commands
+
+Letting the rendering module generate commands from navigation rules is not always exactly what we want. It is likely that all commands could not be deduced from the navigation rules, or that you would like to adapt the names given to the commands. That's why it's also possible to specify the list of commands explicitly as an array of `CommandObject`, or as a function of the array of generic `CommandObject` returning an array of `CommandObject`.
+
+```js
+const rendering = dataNavigator.rendering({
+    ...
+    commandsElement: {
+        include: true,
+        rootId: 'commands-root',
+        commands: [
+            { label: 'Activate the "Enter navigation area" button', description: 'Enter the structure' },
+            { label: '→', description: 'Next data point' },
+            { label: '←', description: 'Previous data point' },
+            { label: 'Esc', description: 'Exit' }
+        ]
+    },
+});
+```
+
+```js
+const rendering = dataNavigator.rendering({
+    ...
+    commandsElement: {
+        include: true,
+        rootId: 'commands-root',
+        commands: genericCommands => genericCommands.filter(c => c.label !== 'Esc'),
+        navigationRules: structure.navigationRules,
+    },
+});
+```
+
+### More complex implementations
+
+If you have a more complex setup, you may need more control over the insertion of the commands table in the DOM. For example if the `rootId` is not in the DOM when `dataNavigator.rendering` is called.
+
+The commands instructions table is a custom element that is exported as `CommandsTable` from the rendering module. You can define it from your own script, set its parameters manually, and add the `commands-table` tag in your HTML template.
+
+```javascript
+customElements.define('commands-table', rendering.CommandsTable);
+document.querySelector('commands-table').commands = [
+    { label: 'Activate the "Enter navigation area" button', description: 'Enter the structure' },
+    { label: '→', description: 'Next data point' },
+    { label: '←', description: 'Previous data point' },
+    { label: 'Esc', description: 'Exit' }
+];
+```
+
+```html
+<commands-table title="Commands instructions"></commands-table>
+```
+
+The util function `getGenericCommandsFromNavRules` is also exposed by the rendering module. It contains the logic behind the generation of generic commands from navigation rules.
+
+## The Complete Code
+
+This code is designed to work without a bundler. Run `npm install data-navigator`, copy the files into a `src/` directory, and open `index.html` in your browser.
+
+::: code-group
+
+```js [coordinator.js]
+import { structure, callbacks } from './structure.js';
+import { drawChart, drawFocusIndicator, createRenderer } from './rendering.js';
+import { createInput } from './input.js';
+
+let current = null;
+let previous = null;
+let input;
+
+function enter() {
+    const nextNode = input.enter();
+    if (nextNode) initiateLifecycle(nextNode);
+}
+
+const renderer = createRenderer(structure, enter);
+input = createInput(structure, renderer.exitElement?.id);
+
+callbacks.onExit = () => {
+    renderer.exitElement.style.display = 'block';
+    input.focus(renderer.exitElement.id);
+    if (current) {
+        renderer.remove(current);
+        current = null;
+    }
+    drawChart(null);
+};
+
+drawChart(null);
+
+function move(direction) {
+    const nextNode = input.move(current, direction);
+    if (nextNode) initiateLifecycle(nextNode);
+}
+
+function initiateLifecycle(nextNode) {
+    if (previous) renderer.remove(previous);
+
+    const element = renderer.render({
+        renderId: nextNode.renderId,
+        datum: nextNode
+    });
+
+    element.addEventListener('keydown', e => {
+        const direction = input.keydownValidator(e);
+        if (direction) {
+            e.preventDefault();
+            move(direction);
+        }
+    });
+
+    element.addEventListener('focus', () => {
+        drawFocusIndicator(nextNode);
+    });
+
+    input.focus(nextNode.renderId);
+    previous = current;
+    current = nextNode.id;
+}
+```
+
+```js [structure.js]
+export const chartWidth = 300;
+export const chartHeight = 300;
+
+// Lookup table for drawing focus outlines on the correct bar.
+export const interactiveData = {
+    data: [
+        [
+            [3, 2.75],
+            [0, 0]
+        ], // apple: [topValues, bottomValues]
+        [
+            [3.75, 4],
+            [3, 2.75]
+        ] // banana: [topValues, bottomValues]
+    ],
+    indices: {
+        fruit: { apple: 0, banana: 1 },
+        store: { a: 0, b: 1 }
+    }
+};
+
+export const callbacks = { onExit: null };
+
+// A simple linked list: 4 data points connected by left/right edges.
+//   [_0] ←→ [_1] ←→ [_2] ←→ [_3]
+export const structure = {
+    nodes: {
+        _0: {
+            id: '_0',
+            renderId: '_0',
+            data: { fruit: 'apple', store: 'a', cost: 3 },
+            edges: ['_0-_1', 'any-exit'],
+            semantics: { label: 'fruit: apple. store: a. cost: 3. Data point.' },
+            spatialProperties: { x: 0, y: 0, width: chartWidth, height: chartHeight }
+        },
+        _1: {
+            id: '_1',
+            renderId: '_1',
+            data: { fruit: 'banana', store: 'a', cost: 0.75 },
+            edges: ['_0-_1', '_1-_2', 'any-exit'],
+            semantics: { label: 'fruit: banana. store: a. cost: 0.75. Data point.' },
+            spatialProperties: { x: 0, y: 0, width: chartWidth, height: chartHeight }
+        },
+        _2: {
+            id: '_2',
+            renderId: '_2',
+            data: { fruit: 'apple', store: 'b', cost: 2.75 },
+            edges: ['_1-_2', '_2-_3', 'any-exit'],
+            semantics: { label: 'fruit: apple. store: b. cost: 2.75. Data point.' },
+            spatialProperties: { x: 0, y: 0, width: chartWidth, height: chartHeight }
+        },
+        _3: {
+            id: '_3',
+            renderId: '_3',
+            data: { fruit: 'banana', store: 'b', cost: 1.25 },
+            edges: ['_2-_3', 'any-exit'],
+            semantics: { label: 'fruit: banana. store: b. cost: 1.25. Data point.' },
+            spatialProperties: { x: 0, y: 0, width: chartWidth, height: chartHeight }
+        }
+    },
+    edges: {
+        '_0-_1': { source: '_0', target: '_1', navigationRules: ['left', 'right'] },
+        '_1-_2': { source: '_1', target: '_2', navigationRules: ['left', 'right'] },
+        '_2-_3': { source: '_2', target: '_3', navigationRules: ['left', 'right'] },
+        'any-exit': {
+            source: (d, c) => c,
+            target: () => {
+                if (callbacks.onExit) callbacks.onExit();
+                return '';
+            },
+            navigationRules: ['exit']
+        }
+    },
+    navigationRules: {
+        left: { key: 'ArrowLeft', direction: 'source' },
+        right: { key: 'ArrowRight', direction: 'target' },
+        exit: { key: 'Escape', direction: 'target' }
+    }
+};
+```
+
+```js [rendering.js]
+import dataNavigator from 'data-navigator';
+import { chartWidth, chartHeight, interactiveData } from './structure.js';
+
+// Draws the Bokeh chart. Pass focusData to add a thick outline
+// around one bar, or null to draw without any indicator.
+export function drawChart(focusData) {
+    const container = document.getElementById('chart');
+    container.innerHTML = '';
+
+    const stores = ['a', 'b'];
+    const p = Bokeh.Plotting.figure({
+        x_range: stores,
+        y_range: [0, 5.5],
+        height: chartHeight,
+        width: chartWidth,
+        title: 'Fruit cost by store',
+        output_backend: 'svg',
+        toolbar_location: null,
+        tools: ''
+    });
+
+    p.vbar({ x: stores, top: [3, 2.75], bottom: [0, 0], width: 0.8, color: '#FCB5B6', line_color: '#8F0002' });
+    p.vbar({ x: stores, top: [3.75, 4], bottom: [3, 2.75], width: 0.8, color: '#F9E782', line_color: '#766500' });
+
+    if (focusData) {
+        p.vbar({
+            x: stores,
+            top: focusData.top,
+            bottom: focusData.bottom,
+            width: 0.8,
+            line_width: 3,
+            color: ['transparent', 'transparent'],
+            line_color: focusData.line_color
+        });
+    }
+
+    const r1 = p.square([-10000], [-10000], { color: '#FCB5B6', line_color: '#8F0002' });
+    const r2 = p.square([-10000], [-10000], { color: '#F9E782', line_color: '#766500' });
+    p.add_layout(
+        new Bokeh.Legend({
+            items: [
+                new Bokeh.LegendItem({ label: 'apple', renderers: [r1] }),
+                new Bokeh.LegendItem({ label: 'banana', renderers: [r2] })
+            ],
+            location: 'top_left',
+            orientation: 'horizontal'
+        })
+    );
+
+    Bokeh.Plotting.show(p, '#chart');
+    const bokehPlot = document.querySelector('#chart');
+    if (bokehPlot) bokehPlot.setAttribute('inert', 'true');
+}
+
+// Redraws the chart with a focus outline on the matching bar.
+export function drawFocusIndicator(node) {
+    if (!node?.data) return;
+    const fruitIndex = interactiveData.indices.fruit[node.data.fruit];
+    const storeIndex = interactiveData.indices.store[node.data.store];
+    const barData = interactiveData.data[fruitIndex];
+    const line_color = storeIndex === 0 ? ['#000000', 'transparent'] : ['transparent', '#000000'];
+    drawChart({ top: barData[0], bottom: barData[1], line_color });
+}
+
+// Creates the accessible HTML layer.
+export function createRenderer(structure, onEnter) {
+    const renderer = dataNavigator.rendering({
+        elementData: structure.nodes,
+        defaults: { cssClass: 'dn-manual-focus-node' },
+        suffixId: 'simple-list',
+        root: {
+            id: 'chart-wrapper',
+            description: 'Fruit cost by store chart. Use arrow keys to navigate.',
+            width: '100%',
+            height: 0
+        },
+        entryButton: { include: true, callbacks: { click: onEnter } },
+        exitElement: { include: true },
+        commandsElement: {
+            include: true,
+            rootId: 'commands-root',
+            commands: [
+                {
+                    label: 'Activate the "Enter navigation area" button',
+                    description: 'Enter the structure'
+                },
+                { label: '→', description: 'Next data point' },
+                { label: '←', description: 'Previous data point' },
+                { label: 'Esc', description: 'Exit' }
+            ]
+        }
+    });
+    renderer.initialize();
+    return renderer;
+}
+```
+
+```js [input.js]
+import dataNavigator from 'data-navigator';
+
+export function createInput(structure, exitPointId) {
+    return dataNavigator.input({
+        structure,
+        navigationRules: structure.navigationRules,
+        entryPoint: '_0',
+        exitPoint: exitPointId
+    });
+}
+```
+
+```html [index.html]
+<html>
+    <head>
+        <link rel="stylesheet" href="./src/style.css" />
+        <script type="importmap">
+            {
+                "imports": {
+                    "data-navigator": "./node_modules/data-navigator/dist/index.mjs"
+                }
+            }
+        </script>
+    </head>
+    <body>
+        <div>
+            <h3>Bar Chart</h3>
+            <div id="commands-root"></div>
+            <div id="chart-wrapper">
+                <div id="chart"></div>
+            </div>
+        </div>
+    </body>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-3.7.3.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-gl-3.7.3.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-3.7.3.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-3.7.3.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.bokeh.org/bokeh/release/bokeh-api-3.7.3.min.js" crossorigin="anonymous"></script>
+    <script type="module" src="./src/coordinator.js"></script>
+</html>
+```
+
+```css [style.css]
+.dn-manual-focus-node {
+    pointer-events: none;
+    background: transparent;
+    border: none;
+    position: absolute;
+    margin: 0px;
+}
+
+.dn-manual-focus-node:focus {
+    outline: 2px solid #1e3369;
+}
+```
+
+:::

--- a/docs/examples/dimensions-api.md
+++ b/docs/examples/dimensions-api.md
@@ -10,17 +10,7 @@ This example uses the same dataset as the [Stacked Bar Chart](/examples/stacked-
 
 <div v-show="showControls">
 
-| Command                       | Key                                         |
-| ----------------------------- | ------------------------------------------- |
-| Enter the structure           | Activate the "Enter navigation area" button |
-| Exit                          | <kbd>Esc</kbd>                              |
-| Left (backward along date)    | <kbd>←</kbd>                                |
-| Right (forward along date)    | <kbd>→</kbd>                                |
-| Up (backward along category)  | <kbd>↑</kbd>                                |
-| Down (forward along category) | <kbd>↓</kbd>                                |
-| Drill down to child           | <kbd>Enter</kbd>                            |
-| Drill up to date parent       | <kbd>W</kbd>                                |
-| Drill up to category parent   | <kbd>J</kbd>                                |
+<div id="commands-root"></div>
 
 At the deepest level, left/right moves across categories and up/down moves across dates. Both dimensions wrap around circularly.
 
@@ -250,7 +240,22 @@ onMounted(async () => {
             height: 0
         },
         entryButton: { include: true, callbacks: { click: enter } },
-        exitElement: { include: true }
+        exitElement: { include: true },
+        commandsElement: {
+            include: true,
+            rootId: 'commands-root',
+            commands: [
+                { label: 'Activate the "Enter navigation area" button', description: 'Enter the structure' },
+                { label: 'Esc', description: 'Exit' },
+                { label: '←', description: 'Left (backward along date)' },
+                { label: '→', description: 'Right (forward along date)' },
+                { label: '↑', description: 'Up (backward along category)' },
+                { label: '↓', description: 'Down (forward along category)' },
+                { label: 'Enter', description: 'Drill down to child' },
+                { label: 'W', description: 'Drill up to date parent' },
+                { label: 'J', description: 'Drill up to category parent' }
+            ],
+        }
     });
     rendering.initialize();
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -14,6 +14,7 @@ Interactive examples showing Data Navigator in action with different chart types
 - [Data Text Adventure](/examples/data-text-adventure) — A text adventure-style interface for navigating data structures without keyboard focus, designed for mobile and screen reader users.
 - [LLM Text Adventure](/examples/llm-text-adventure) — Extends the text adventure with an optional AI assistant powered by Claude, enabling natural-language questions about the data.
 - [Interactive Elements](/examples/interactive-elements) — A Bokeh scatter chart with clickable data points. Demonstrates how mouse, keyboard, and text-chat users can all select and interact with chart elements using a single `onClick` callback.
+- [Commands Instructions](/examples/commands-instructions) — An example of usign the rendering API to display the built-in commands insturctions table.
 
 ## Planned
 

--- a/docs/examples/simple-list.md
+++ b/docs/examples/simple-list.md
@@ -8,12 +8,7 @@ This example shows a simple linked-list navigation structure on a Bokeh stacked 
 
 <div v-show="showControls">
 
-| Command             | Key                                         |
-| ------------------- | ------------------------------------------- |
-| Enter the structure | Activate the "Enter navigation area" button |
-| Exit                | <kbd>Esc</kbd>                              |
-| Previous data point | <kbd>←</kbd>                                |
-| Next data point     | <kbd>→</kbd>                                |
+<div id="commands-root"></div>
 
 </div>
 
@@ -239,7 +234,13 @@ onMounted(async () => {
                 height: 0
             },
             entryButton: { include: true, callbacks: { click: enter } },
-            exitElement: { include: true }
+            exitElement: { include: true },
+            commandsElement: {
+                include: true,
+                rootId: 'commands-root',
+                navigationRules: structure.navigationRules,
+                commands: (genericCommands => [{label: 'Activate the "Enter navigation area" button', description: 'Enter the structure'}, ...genericCommands]),
+            }
         });
         rendering.initialize();
 

--- a/packages/data-navigator/src/commands-table.js
+++ b/packages/data-navigator/src/commands-table.js
@@ -1,0 +1,116 @@
+import { commandsTableDefaultColumns } from './consts';
+
+export class CommandsTable extends HTMLElement {
+    #commands = [];
+    #columns = commandsTableDefaultColumns;
+    #connected = false;
+
+    static get observedAttributes() {
+        return ['title'];
+    }
+
+    set commands(value) {
+        this.#commands = value;
+        if (!this.#connected) return;
+        this.#render();
+    }
+
+    get commands() {
+        return this.#commands;
+    }
+
+    set columns(value) {
+        this.#columns = value;
+        if (!this.#connected) return;
+        this.#render();
+    }
+
+    get columns() {
+        return this.#columns;
+    }
+
+    attributeChangedCallback() {
+        //  Avoid render when the attribute changes on init
+        if (!this.#connected) return;
+        this.#render();
+    }
+
+    connectedCallback() {
+        this.#connected = true;
+        this.#render();
+    }
+
+    #render() {
+        this.replaceChildren();
+
+        const headerCells = [];
+        for (const column of this.#columns) {
+            const headerCell = document.createElement('th');
+            headerCell.classList.add('dn-commands-table-th');
+            headerCell.textContent = column.label;
+
+            headerCells.push(headerCell);
+        }
+
+        const headerRow = document.createElement('tr');
+        headerRow.classList.add('dn-commands-table-thead-tr');
+        for (const headerCell of headerCells) {
+            headerRow.appendChild(headerCell);
+        }
+
+        const thead = document.createElement('thead');
+        thead.classList.add('dn-commands-table-thead');
+        thead.appendChild(headerRow);
+
+        const tbody = document.createElement('tbody');
+        tbody.classList.add('dn-commands-table-tbody');
+        for (const command of this.#commands) {
+            const rowCells = [];
+
+            for (const column of this.#columns) {
+                const cellValue = command[column.id];
+
+                const rowCell = document.createElement('td');
+                rowCell.classList.add('dn-commands-table-td');
+                if (column.id === 'label' && cellValue) {
+                    const kbd = document.createElement('kbd');
+                    kbd.classList.add('dn-commands-table-td-kbd');
+                    kbd.textContent = cellValue;
+                    rowCell.append(kbd);
+                } else {
+                    rowCell.textContent = cellValue;
+                }
+
+                rowCells.push(rowCell);
+            }
+
+            const row = document.createElement('tr');
+            row.classList.add('dn-commands-table-tbody-tr');
+            for (const rowCell of rowCells) {
+                row.appendChild(rowCell);
+            }
+
+            tbody.appendChild(row);
+        }
+
+        const table = document.createElement('table');
+        table.classList.add('dn-commands-table');
+
+        const title = this.getAttribute('title');
+        if (title) {
+            const caption = document.createElement('caption');
+            caption.classList.add('dn-commands-table-caption');
+            caption.textContent = title;
+            table.appendChild(caption);
+        }
+
+        table.appendChild(thead);
+        table.appendChild(tbody);
+
+        this.appendChild(table);
+    }
+
+    disconnectedCallback() {
+        this.#connected = false;
+    }
+}

--- a/packages/data-navigator/src/consts.ts
+++ b/packages/data-navigator/src/consts.ts
@@ -1,4 +1,4 @@
-import type { DatumObject, NavigationRules, RenderObject } from './data-navigator';
+import type { DatumObject, CommandObject, NavigationRules, RenderObject, NavId } from './data-navigator';
 
 export const SemanticKeys = {
     Escape: true,
@@ -171,3 +171,17 @@ export const NodeElementDefaults = {
         spatialProperties: undefined
     }
 } as RenderObject;
+
+export const GenericNavigationRuleCommands: Record<NavId, CommandObject> = {
+    enter: { label: 'Enter', description: 'Drill down' },
+    exit: { label: 'Esc', description: 'Exit' },
+    left: { label: '←', description: 'Previous data point' },
+    right: { label: '→', description: 'Next data point' },
+    up: { label: '↑', description: 'Previous data point' },
+    down: { label: '↓', description: 'Next data point' }
+};
+
+export const commandsTableDefaultColumns = [
+    { label: 'Command', id: 'description' },
+    { label: 'Key', id: 'label' }
+];

--- a/packages/data-navigator/src/data-navigator.ts
+++ b/packages/data-navigator/src/data-navigator.ts
@@ -25,6 +25,7 @@ export type RenderingOptions = {
     defaults?: RenderObject;
     entryButton?: EntryObject;
     exitElement?: ExitObject;
+    commandsElement?: CommandsObject;
 };
 
 export type DimensionOptions = {
@@ -178,6 +179,20 @@ export type EntryObject = {
 export type ExitObject = {
     include: boolean;
     callbacks?: ExitCallbacks;
+};
+
+export type CommandsObject = {
+    include: boolean;
+    rootId?: string;
+    navigationRules?: NavigationRules;
+    commands?: Array<CommandObject> | ((genericCommands: Array<CommandObject>) => Array<CommandObject>);
+    columns?: Array<{ label: string; id: string }>;
+    title?: string;
+};
+
+export type CommandObject = {
+    label: string;
+    description: string;
 };
 
 export type SemanticsObject = {

--- a/packages/data-navigator/src/rendering.ts
+++ b/packages/data-navigator/src/rendering.ts
@@ -1,5 +1,7 @@
+import { CommandsTable } from './commands-table';
 import { NodeElementDefaults } from './consts';
-import type { RenderingOptions, NodeObject } from './data-navigator';
+import type { RenderingOptions, NodeObject, CommandsObject } from './data-navigator';
+import { getGenericCommandsFromNavRules } from './utilities';
 
 export default (options: RenderingOptions) => {
     const setActiveDescendant = e => {
@@ -65,7 +67,9 @@ export default (options: RenderingOptions) => {
             renderer.wrapper.style.height = options.root.height;
         }
 
-        // TO-DO: build interaction instructions/menu
+        if (options.commandsElement?.include) {
+            renderer.initializeCommands(options.commandsElement);
+        }
 
         // build entry button
         if (options.entryButton && options.entryButton.include) {
@@ -223,5 +227,53 @@ export default (options: RenderingOptions) => {
             }
         });
     };
+    renderer.initializeCommands = (commandOptions: CommandsObject) => {
+        //  Find the element within which the commands table must be inserted
+        const root = document.getElementById(commandOptions?.rootId);
+
+        if (!root) {
+            console.error('Commands root element not found in document.');
+            return;
+        }
+
+        //  Consider explicit commands if given, otherwise try to build generic commands from nav rules
+        const optionsCommands = commandOptions.commands;
+
+        const genericCommandsFromRules = getGenericCommandsFromNavRules(commandOptions.navigationRules);
+
+        const commands = optionsCommands
+            ? typeof optionsCommands === 'function'
+                ? optionsCommands(genericCommandsFromRules)
+                : optionsCommands
+            : genericCommandsFromRules;
+
+        if (!customElements.get('commands-table')) {
+            customElements.define('commands-table', CommandsTable);
+        }
+
+        const commandsElement = document.createElement('commands-table') as CommandsTable;
+
+        //  Pass the title attribute to the custom element
+        if (commandOptions?.title) {
+            commandsElement.setAttribute('title', commandOptions.title);
+        }
+
+        //  Set the commands property on the custom element
+        commandsElement.commands = commands;
+
+        if (commandOptions.columns) {
+            //  Set the columns property on the custom element
+            commandsElement.columns = commandOptions.columns;
+        }
+
+        root.appendChild(commandsElement);
+
+        return commandsElement;
+    };
+
+    //  Expose util function and custom element that can be used to create the commands table
+    //  without setting options.commandsElement
+    renderer.getGenericCommandsFromNavRules = getGenericCommandsFromNavRules;
+    renderer.CommandsTable = CommandsTable;
     return renderer;
 };

--- a/packages/data-navigator/src/utilities.ts
+++ b/packages/data-navigator/src/utilities.ts
@@ -1,4 +1,5 @@
-import { DatumObject, DescriptionOptions } from './data-navigator';
+import { GenericNavigationRuleCommands } from './consts';
+import { CommandObject, DatumObject, DescriptionOptions, NavigationRules } from './data-navigator';
 
 export const describeNode = (d: DatumObject, descriptionOptions?: DescriptionOptions) => {
     const keys = Object.keys(d);
@@ -14,3 +15,12 @@ export const createValidId = (s: string): string => {
     // We start the string with an underscore, then replace all invalid characters with underscores
     return '_' + s.replace(/[^a-zA-Z0-9_-]+/g, '_');
 };
+
+export function getGenericCommandsFromNavRules(navigationRules?: NavigationRules): CommandObject[] {
+    if (!navigationRules) {
+        return [];
+    }
+    return Object.keys(navigationRules)
+        .map(navId => GenericNavigationRuleCommands[navId])
+        .filter(Boolean);
+}


### PR DESCRIPTION
Related Issue: https://github.com/cmudig/data-navigator/issues/73

The goal of this PR is to give the data-navigator users a way to easily generate a table of navigation commands.

Steps:
- [x] Create a custom table element
- [x] Add api to rendering module
- [x] Manual tests with both api & handmade declarative custom element
- [x] Make sure it works with docs examples, & intergate with docs
- [ ] Explore better commands table generation based on dimensions ?
- [ ] Enhance `CommandObject` with "keyboard"/"vocal" command input types ?

Tested on: 
- [x] Voiceover + Safari / Chrome
- [x] NVDA + Edge / Firefox

## Commits
1st commit: custom element. It takes the following input properties & attributes:
- `commands: Array<CommandObject>`  
- `columns: Array<{label: string, id: string}>` that defaults to the columns that are used in the docs
- `title: string`

2nd and 3rd commits: Adaptation of the rendering module. The new bit of the rendering API is the following: 
```typescript
{
	commandsElement?: {
		include: boolean;
		rootId?: string;
		navigationRules?: NavigationRules;
		commands?: Array<CommandObject> | ((genericCommands: Array<CommandObject>) => Array<CommandObject>);
		columns?: { label: string; id: string }[];
		title?: string;
	};
}
```

4th commit: New docs page that explains the different methods to add the commands.

5th commit: example of the use of the feature in the docs pages "Simple List Navigation" and "Dimensions API Example". I waited to have a general review of the structure of the feature before implementing it everywhere else in the doc, but it seems pretty straightforward from here.

### The `CommandObject` type

```typescript
export type CommandObject = {
	label: string;
	description: string;
};
```
For a command such as "Left (backward along date)" | "←", I considered that "←" is just a display label of the command inputs.
The type could evolve by adding a "keyboard" and a "vocal" key on the type, and a `{name: "Keyboard Input", id: "keyboard"}` `{name: "Vocal Input", id: "vocal"}` in the table columns.

With that type, the `commandLabels?: Record<string, string>` could just be `CommandObject` where the `Record` key is the "label" and the `Record` value is the "description". Or the `Record` key could be another property on the `CommandObject` type such as "text" if it should be distinct type of command input.

It's still a little confusing code-wise that the docs table has the "Key" column that displays the "label" of the `CommandObject`. But it seems to make more sense for the user that the "Key" is actually not the keyboard input code.

### Improve `getGenericCommandsFromNavRules` 
As you can see from the implementation in the "Dimensions API Example" doc, the `GenericNavigationRuleCommands` are not enough to build the same commands table. The commands still need to be hand-written in the `commandsElement.commands` rendering option.

If we wanted a more useful auto-generation of commands in that case, we could get more info by using the dimensions of the structure (if they exist) along with the navigation rules. But this would make `getGenericCommandsFromNavRules` more complex and I'd like to know it it seems like a good idea before exploring it more.